### PR TITLE
Add Analytics screen: Income vs Expenses (12 months)

### DIFF
--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -21,6 +21,7 @@ type RouteKey =
   | 'analytics.accounts.groupings'
   | 'analytics.accounts.groupings.edit'
   | 'analytics.balance'
+  | 'analytics.income_expenses'
   | 'analytics.categories'
   | 'categories'
   | 'categories.create'
@@ -97,6 +98,10 @@ export const routes: { [key in RouteKey]: Route } = {
   },
   'analytics.balance': {
     path: '/analytics/balance',
+    title: 'analytics.title',
+  },
+  'analytics.income_expenses': {
+    path: '/analytics/income-expenses',
     title: 'analytics.title',
   },
   'analytics.categories': {

--- a/src/lib/translate/en.ts
+++ b/src/lib/translate/en.ts
@@ -132,6 +132,8 @@ export const enDict: Dictionary = {
   'analytics.accounts.grouping.select_grouping': 'Select grouping',
   'analytics.accounts.hide_zero_balance_accounts': 'Hide zero balance accounts',
   'analytics.balance.legend': 'Legend',
+  'analytics.income_expenses.title': 'Income / Expenses',
+  'analytics.income_expenses.total_diff': 'Income - expenses for 12 months',
   'analytics.groupings.title': 'Groupings',
   'analytics.groupings.create_grouping': 'Add grouping',
   'analytics.groupings.new_grouping': 'New grouping',

--- a/src/lib/translate/en.ts
+++ b/src/lib/translate/en.ts
@@ -133,7 +133,7 @@ export const enDict: Dictionary = {
   'analytics.accounts.hide_zero_balance_accounts': 'Hide zero balance accounts',
   'analytics.balance.legend': 'Legend',
   'analytics.income_expenses.title': 'Income / Expenses',
-  'analytics.income_expenses.total_diff': 'Income - expenses for 12 months',
+  'analytics.income_expenses.total_diff': 'Income - expenses for selected period',
   'analytics.groupings.title': 'Groupings',
   'analytics.groupings.create_grouping': 'Add grouping',
   'analytics.groupings.new_grouping': 'New grouping',

--- a/src/lib/translate/messages.ts
+++ b/src/lib/translate/messages.ts
@@ -127,6 +127,8 @@ export type Messages =
   | 'analytics.accounts.grouping.select_grouping'
   | 'analytics.accounts.hide_zero_balance_accounts'
   | 'analytics.balance.legend'
+  | 'analytics.income_expenses.title'
+  | 'analytics.income_expenses.total_diff'
   | 'analytics.groupings.title'
   | 'analytics.groupings.create_grouping'
   | 'analytics.groupings.new_grouping'

--- a/src/lib/translate/ru.ts
+++ b/src/lib/translate/ru.ts
@@ -133,6 +133,8 @@ export const ruDict: Dictionary = {
   'analytics.accounts.grouping.select_grouping': 'Выбрать группировку',
   'analytics.accounts.hide_zero_balance_accounts': 'Скрыть счета с нулевым балансом',
   'analytics.balance.legend': 'Легенда',
+  'analytics.income_expenses.title': 'Доходы / Расходы',
+  'analytics.income_expenses.total_diff': 'Доходы - расходы за 12 месяцев',
   'analytics.groupings.title': 'Группировки',
   'analytics.groupings.create_grouping': 'Добавить группировку',
   'analytics.groupings.new_grouping': 'Новая группировка',

--- a/src/lib/translate/ru.ts
+++ b/src/lib/translate/ru.ts
@@ -134,7 +134,7 @@ export const ruDict: Dictionary = {
   'analytics.accounts.hide_zero_balance_accounts': 'Скрыть счета с нулевым балансом',
   'analytics.balance.legend': 'Легенда',
   'analytics.income_expenses.title': 'Доходы / Расходы',
-  'analytics.income_expenses.total_diff': 'Доходы - расходы за 12 месяцев',
+  'analytics.income_expenses.total_diff': 'Доходы - расходы за выбранный период',
   'analytics.groupings.title': 'Группировки',
   'analytics.groupings.create_grouping': 'Добавить группировку',
   'analytics.groupings.new_grouping': 'Новая группировка',

--- a/src/routes/analytics/AnalyticsButtonsRight.svelte
+++ b/src/routes/analytics/AnalyticsButtonsRight.svelte
@@ -7,4 +7,9 @@
 <div class="flex">
   <HeaderButton icon="mdi:briefcase-outline" label={$translate('accounts.title')} href={route('analytics.accounts')} />
   <HeaderButton icon="mdi:chart-line" label={$translate('analytics.title')} href={route('analytics.balance')} />
+  <HeaderButton
+    icon="mdi:chart-bar"
+    label={$translate('analytics.income_expenses.title')}
+    href={route('analytics.income_expenses')}
+  />
 </div>

--- a/src/routes/analytics/balance/BalanceChart.svelte
+++ b/src/routes/analytics/balance/BalanceChart.svelte
@@ -37,13 +37,12 @@
 
   const findRateFn = (currency: string) => findRate(currencyRates, mainCurrency, currency);
 
-  let interval: 12 | 6 | 3 | 1 = 12;
+  let interval: 6 | 12 | 24 = 12;
 
   const changeInterval = () => {
-    if (interval === 12) interval = 6;
-    else if (interval === 6) interval = 3;
-    else if (interval === 3) interval = 1;
-    else interval = 12;
+    if (interval === 6) interval = 12;
+    else if (interval === 12) interval = 24;
+    else interval = 6;
   };
 
   const endDate = dayjs();

--- a/src/routes/analytics/balance/BalanceChart.svelte
+++ b/src/routes/analytics/balance/BalanceChart.svelte
@@ -37,12 +37,14 @@
 
   const findRateFn = (currency: string) => findRate(currencyRates, mainCurrency, currency);
 
-  let interval: 6 | 12 | 24 = 12;
+  let interval: 1 | 3 | 6 | 12 | 24 = 12;
 
   const changeInterval = () => {
-    if (interval === 6) interval = 12;
+    if (interval === 1) interval = 3;
+    else if (interval === 3) interval = 6;
+    else if (interval === 6) interval = 12;
     else if (interval === 12) interval = 24;
-    else interval = 6;
+    else interval = 1;
   };
 
   const endDate = dayjs();

--- a/src/routes/analytics/income-expenses/+page.svelte
+++ b/src/routes/analytics/income-expenses/+page.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { translate } from '$lib/translate';
+  import Layout from '$lib/ui/layout/Layout.svelte';
+
+  import AnalyticsButtonsLeft from '../AnalyticsButtonsLeft.svelte';
+  import AnalyticsButtonsRight from '../AnalyticsButtonsRight.svelte';
+  import IncomeExpensesChart from './IncomeExpensesChart.svelte';
+</script>
+
+<Layout title={$translate('analytics.title')} leftSlot={AnalyticsButtonsLeft} rightSlot={AnalyticsButtonsRight}>
+  <IncomeExpensesChart />
+</Layout>

--- a/src/routes/analytics/income-expenses/IncomeExpensesChart.svelte
+++ b/src/routes/analytics/income-expenses/IncomeExpensesChart.svelte
@@ -46,7 +46,7 @@
 
 <div class="chart-container">
   <Chart
-    type="bar"
+    type="line"
     updateMode="none"
     data={{
       labels: monthStats.map((x) => x.month.format('MMM YY')),
@@ -54,14 +54,20 @@
         {
           label: $translate('categories.incomings'),
           data: monthStats.map((item) => item.income),
-          backgroundColor: '#16a34a',
-          borderRadius: 6,
+          borderColor: '#16a34a',
+          backgroundColor: 'rgba(22, 163, 74, 0.15)',
+          fill: false,
+          tension: 0.35,
+          pointRadius: 3,
         },
         {
           label: $translate('categories.outgoings'),
           data: monthStats.map((item) => item.expenses),
-          backgroundColor: '#dc2626',
-          borderRadius: 6,
+          borderColor: '#dc2626',
+          backgroundColor: 'rgba(220, 38, 38, 0.15)',
+          fill: false,
+          tension: 0.35,
+          pointRadius: 3,
         },
       ],
     }}

--- a/src/routes/analytics/income-expenses/IncomeExpensesChart.svelte
+++ b/src/routes/analytics/income-expenses/IncomeExpensesChart.svelte
@@ -1,0 +1,104 @@
+<script lang="ts">
+  import dayjs from 'dayjs';
+
+  import { currencyRatesStore, memberSettingsStore, operationsStore } from '$lib/data';
+  import { translate } from '$lib/translate';
+  import { findRate, formatMoney } from '$lib/utils';
+
+  import Chart from '../balance/Chart.svelte';
+
+  const currencyRates = $currencyRatesStore;
+  const settings = $memberSettingsStore;
+  $: operations = $operationsStore;
+
+  const mainCurrency = settings?.currency ?? 'USD';
+
+  $: findRateFn = (currency: string) => findRate(currencyRates, mainCurrency, currency);
+
+  const monthsCount = 12;
+  const startMonth = dayjs().startOf('month').subtract(monthsCount - 1, 'month');
+
+  $: months = Array.from({ length: monthsCount }, (_, index) => startMonth.add(index, 'month'));
+
+  $: monthStats = months.map((month) => {
+    const monthOperations = operations.filter(
+      (t) => dayjs(t.date).isSame(month, 'month') && !t.excludeFromAnalysis && !t.category.system,
+    );
+
+    let income = 0;
+    let expenses = 0;
+
+    monthOperations.forEach((operation) => {
+      const amount = operation.amount * findRateFn(operation.account.currency);
+      if (operation.category.type === 'IN') income += amount;
+      else expenses += amount;
+    });
+
+    return {
+      month,
+      income,
+      expenses,
+    };
+  });
+
+  $: balanceDiff = monthStats.reduce((sum, item) => sum + item.income - item.expenses, 0);
+</script>
+
+<div class="chart-container">
+  <Chart
+    type="bar"
+    updateMode="none"
+    data={{
+      labels: monthStats.map((x) => x.month.format('MMM YY')),
+      datasets: [
+        {
+          label: $translate('categories.incomings'),
+          data: monthStats.map((item) => item.income),
+          backgroundColor: '#16a34a',
+          borderRadius: 6,
+        },
+        {
+          label: $translate('categories.outgoings'),
+          data: monthStats.map((item) => item.expenses),
+          backgroundColor: '#dc2626',
+          borderRadius: 6,
+        },
+      ],
+    }}
+    options={{
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: {
+        intersect: false,
+      },
+      scales: {
+        y: {
+          position: 'right',
+        },
+      },
+    }}
+  />
+</div>
+
+<div class="summary">
+  <span>{$translate('analytics.income_expenses.total_diff')}:</span>
+  <strong class:negative={balanceDiff < 0}>{formatMoney(balanceDiff, { currency: mainCurrency })}</strong>
+</div>
+
+<style>
+  .chart-container {
+    position: relative;
+    height: calc(100% - 3rem);
+    width: 100%;
+    padding: 1rem;
+  }
+  .summary {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    padding: 0 1rem 1rem;
+  }
+  .negative {
+    color: #dc2626;
+  }
+</style>

--- a/src/routes/analytics/income-expenses/IncomeExpensesChart.svelte
+++ b/src/routes/analytics/income-expenses/IncomeExpensesChart.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import dayjs from 'dayjs';
 
+  import Button from '@ya-erm/svelte-ui/Button';
+  import Icon from '@ya-erm/svelte-ui/Icon';
+
   import { currencyRatesStore, memberSettingsStore, operationsStore } from '$lib/data';
   import { translate } from '$lib/translate';
   import { findRate, formatMoney } from '$lib/utils';
@@ -15,10 +18,19 @@
 
   $: findRateFn = (currency: string) => findRate(currencyRates, mainCurrency, currency);
 
-  const monthsCount = 12;
-  const startMonth = dayjs().startOf('month').subtract(monthsCount - 1, 'month');
+  let interval: 6 | 12 | 24 = 12;
 
-  $: months = Array.from({ length: monthsCount }, (_, index) => startMonth.add(index, 'month'));
+  const changeInterval = () => {
+    if (interval === 6) interval = 12;
+    else if (interval === 12) interval = 24;
+    else interval = 6;
+  };
+
+  $: startMonth = dayjs()
+    .startOf('month')
+    .subtract(interval - 1, 'month');
+
+  $: months = Array.from({ length: interval }, (_, index) => startMonth.add(index, 'month'));
 
   $: monthStats = months.map((month) => {
     const monthOperations = operations.filter(
@@ -45,6 +57,12 @@
 </script>
 
 <div class="chart-container">
+  <div class="interval-button flex items-start gap-0.5">
+    <Button color="white" bordered onClick={changeInterval}>
+      <Icon name="mdi:arrow-expand-horizontal" />
+      {interval}M
+    </Button>
+  </div>
   <Chart
     type="line"
     updateMode="none"
@@ -97,6 +115,12 @@
     height: calc(100% - 3rem);
     width: 100%;
     padding: 1rem;
+  }
+  .interval-button {
+    position: absolute;
+    top: 1rem;
+    left: 1rem;
+    z-index: 1;
   }
   .summary {
     display: flex;


### PR DESCRIPTION
### Motivation

- Provide a new Analytics view that displays monthly incomes and expenses as a chart so users can compare and confirm expenses do not exceed incomes over time.

### Description

- Added a new route and page at `/analytics/income-expenses` (`src/routes/analytics/income-expenses/+page.svelte`) which hosts the chart component. 
- Implemented `IncomeExpensesChart.svelte` (`src/routes/analytics/income-expenses/IncomeExpensesChart.svelte`) that aggregates operations for the last 12 months, converts amounts to the main currency and renders a grouped bar chart (income vs expenses) using the existing `Chart.svelte` component. 
- Registered the route key `analytics.income_expenses` in `src/lib/routes.ts` and added a navigation button to the analytics header in `src/routes/analytics/AnalyticsButtonsRight.svelte` for quick access. 
- Added localization keys in `src/lib/translate/en.ts` and `src/lib/translate/ru.ts` and updated the `Messages` type in `src/lib/translate/messages.ts` for the new labels. 

### Testing

- Ran `pnpm -s check`; new translations and route typings were fixed and type-aware, but a pre-existing unrelated TypeScript error remains in `src/routes/settings/logs/+page.svelte` (`log.id` does not exist on type `LogMessage`), causing the overall type check to fail. 
- Aside from that unrelated existing error, the new analytics screen files type-check and integrate with the chart component.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3cd10f380832a9490bbf1afc84f65)